### PR TITLE
Strict web3-eth-abi 1.0.0-beta.55 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typedarray-to-buffer": "^3.1.5",
     "web3": "1.0.0-beta.55",
     "web3-eth": "1.0.0-beta.55",
-    "web3-eth-abi": "^1.0.0-beta.55",
+    "web3-eth-abi": "1.0.0-beta.55",
     "web3-utils": "1.0.0-beta.55"
   },
   "devDependencies": {


### PR DESCRIPTION
The newer version of web3 don't have retrocompatibility